### PR TITLE
Make services non-static

### DIFF
--- a/src/Domain/DoGeneric.php
+++ b/src/Domain/DoGeneric.php
@@ -2,18 +2,30 @@
 namespace Wheniwork\Feedback\Domain;
 
 use RuntimeException;
+use Wheniwork\Feedback\Service\Authorizer;
+use Wheniwork\Feedback\Service\GithubService;
+use Wheniwork\Feedback\Service\HipChatService;
 
 class DoGeneric extends FeedbackDomain
 {
+    private $auth;
+
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        Authorizer $auth
+    ) {
+        parent::__construct($hipchat, $github);
+        $this->auth = $auth;
+    }
+
     public function __invoke(array $input)
     {
         $payload = $this->getPayload();
 
         try {
-            if (empty($input['key'])) {
-                throw new RuntimeException("You must provide a key with your request.");
-            } else if ($input['key'] != $_ENV['POST_KEY']) {
-                throw new RuntimeException("The provided authentication key was invalid.");
+            if (! $this->auth->checkInput($input)) {
+                throw new RuntimeException("Unable to authenticate.");
             }
 
             if (empty($input['body'])) {

--- a/src/Domain/DoGeneric.php
+++ b/src/Domain/DoGeneric.php
@@ -6,54 +6,32 @@ use Wheniwork\Feedback\Service\Authorizer;
 use Wheniwork\Feedback\Service\GithubService;
 use Wheniwork\Feedback\Service\HipChatService;
 
-class DoGeneric extends FeedbackDomain
+class DoGeneric extends FeedbackPostDomain
 {
-    private $auth;
-
-    public function __construct(
-        HipChatService $hipchat,
-        GithubService $github,
-        Authorizer $auth
-    ) {
-        parent::__construct($hipchat, $github);
-        $this->auth = $auth;
+    protected function getRequiredFields()
+    {
+        return [
+            'body',
+            'source'
+        ];
     }
 
-    public function __invoke(array $input)
+    protected function getFeedbackHTML(array $input)
     {
-        $payload = $this->getPayload();
+        return $input['body'];
+    }
 
-        try {
-            if (! $this->auth->checkInput($input)) {
-                throw new RuntimeException("Unable to authenticate.");
-            }
+    protected function getSourceName(array $input)
+    {
+        return $input['source'];
+    }
 
-            if (empty($input['body'])) {
-                throw new RuntimeException("Missing required field 'body'");
-            }
-            if (empty($input['source'])) {
-                throw new RuntimeException("Missing required field 'source'");
-            }
-
-            $tone = self::NEUTRAL;
-            if (!empty($input['tone'])) {
-                $tone = strtoupper($input['tone']);
-            }
-
-            $this->createFeedback($input['body'], $input['source'], $tone);
-
-            $payload->setStatus($payload::SUCCESS);
-            $payload->setOutput([
-                'new_feedback' => [
-                    'body' => $input['body'],
-                    'source' => $input['source']
-                ]
-            ]);
-        } catch (Exception $e) {
-            $payload->setStatus($payload::ERROR);
-            $payload->setOutput($e);
+    protected function getTone(array $input)
+    {
+        $tone = self::NEUTRAL;
+        if (!empty($input['tone'])) {
+            $tone = strtoupper($input['tone']);
         }
-
-        return $payload;
+        return $tone;
     }
 }

--- a/src/Domain/DoZendesk.php
+++ b/src/Domain/DoZendesk.php
@@ -2,18 +2,30 @@
 namespace Wheniwork\Feedback\Domain;
 
 use RuntimeException;
+use Wheniwork\Feedback\Service\Authorizer;
+use Wheniwork\Feedback\Service\GithubService;
+use Wheniwork\Feedback\Service\HipChatService;
 
 class DoZendesk extends FeedbackDomain
 {
+    private $auth;
+
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        Authorizer $auth
+    ) {
+        parent::__construct($hipchat, $github);
+        $this->auth = $auth;
+    }
+
     public function __invoke(array $input)
     {
         $payload = $this->getPayload();
 
         try {
-            if (empty($input['key'])) {
-                throw new RuntimeException("You must provide a key with your request.");
-            } else if ($input['key'] != $_ENV['POST_KEY']) {
-                throw new RuntimeException("The provided authentication key was invalid.");
+            if (! $this->auth->checkInput($input)) {
+                throw new RuntimeException("Unable to authenticate.");
             }
 
             if (empty($input['body'])) {

--- a/src/Domain/FeedbackDomain.php
+++ b/src/Domain/FeedbackDomain.php
@@ -13,6 +13,17 @@ abstract class FeedbackDomain implements DomainInterface
     const NEGATIVE = 'NEGATIVE';
     const NEUTRAL = 'NEUTRAL';
 
+    private $hipchat;
+    private $github;
+
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github
+    ) {
+        $this->hipchat = $hipchat;
+        $this->github = $github;
+    }
+
     public function getPayload()
     {
         return new Payload();
@@ -38,9 +49,9 @@ abstract class FeedbackDomain implements DomainInterface
     protected function createFeedback($body, $source, $tone = self::NEUTRAL)
     {
         $color = $this->colorForTone($tone);
-        HipChatService::postMessage("<strong>From $source:</strong> $body", $color);
+        $this->hipchat->postMessage("<strong>From $source:</strong> $body", $color);
 
-        GithubService::createIssue("Feedback from $source", $body);
+        $this->github->createIssue("Feedback from $source", $body);
     }
 
     /**

--- a/src/Domain/FeedbackGetDomain.php
+++ b/src/Domain/FeedbackGetDomain.php
@@ -2,13 +2,19 @@
 namespace Wheniwork\Feedback\Domain;
 
 use Predis\Client as RedisClient;
+use Wheniwork\Feedback\Service\HipChatService;
+use Wheniwork\Feedback\Service\GithubService;
 
 abstract class FeedbackGetDomain extends FeedbackDomain
 {
-    protected $redis;
-
-    public function __construct(RedisClient $redis)
-    {
+    private $redis;
+    
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        RedisClient $redis
+    ) {
+        parent::__construct($hipchat, $github);
         $this->redis = $redis;
     }
 
@@ -57,7 +63,8 @@ abstract class FeedbackGetDomain extends FeedbackDomain
     /**
      * Gets the cached value for this domain from Redis.
      */
-    protected function getRedisValue() {
+    protected function getRedisValue()
+    {
         return $this->redis->get($this->getRedisKey());
     }
 
@@ -66,7 +73,8 @@ abstract class FeedbackGetDomain extends FeedbackDomain
      *
      * @param int $value    The value to save in Redis.
      */
-    protected function setRedisValue($value) {
+    protected function setRedisValue($value)
+    {
         $this->redis->set($this->getRedisKey(), $value);
     }
 

--- a/src/Domain/FeedbackPostDomain.php
+++ b/src/Domain/FeedbackPostDomain.php
@@ -1,0 +1,102 @@
+<?php
+namespace Wheniwork\Feedback\Domain;
+
+use RuntimeException;
+use Wheniwork\Feedback\Service\Authorizer;
+use Wheniwork\Feedback\Service\GithubService;
+use Wheniwork\Feedback\Service\HipChatService;
+
+abstract class FeedbackPostDomain extends FeedbackDomain
+{
+    private $auth;
+
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        Authorizer $auth
+    ) {
+        parent::__construct($hipchat, $github);
+        $this->auth = $auth;
+    }
+
+    public function __invoke(array $input)
+    {
+        $payload = $this->getPayload();
+
+        try {
+            $this->auth->ensure($input);
+
+            $missing = array_diff($this->getRequiredFields(), array_keys($input));
+            if (!empty($missing)) {
+                throw new RuntimeException(
+                    'Missing required fields: ' .
+                    implode(', ', $missing)
+                );
+            }
+
+            if ($this->isValid($input)) {
+                $body = $this->getFeedbackHTML($input);
+                $source = $this->getSourceName($input);
+                $this->createFeedback($body, $source);
+
+                $payload->setStatus($payload::SUCCESS);
+                $payload->setOutput([
+                    'new_feedback' => [
+                        'body' => $body,
+                        'source' => $source
+                    ]
+                ]);
+            } else {
+                $payload->setStatus($payload::NOT_VALID);
+                $payload->setOutput([
+                    'error' => 'Input was not valid.'
+                ]);
+            }
+        } catch (Exception $e) {
+            $payload->setStatus($payload::ERROR);
+            $payload->setOutput($e);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Gets the input fields that are required by this domain.
+     * @return array The required fields, as an array of strings.
+     */
+    abstract protected function getRequiredFields();
+
+    /**
+     * Checks whether the given input is valid.
+     * @param  array   $input The input for the domain.
+     * @return boolean        Whether the input is valid.
+     */
+    protected function isValid(array $input)
+    {
+        return true;
+    }
+
+    /**
+     * Gets the HTML-formatted feedback from the given input.
+     * @param  array  $input The input for the domain.
+     * @return string        The HTML-formatted feedback.
+     */
+    abstract protected function getFeedbackHTML(array $input);
+
+    /**
+     * Gets the source name for this domain.
+     * @param  array  $input The input for the domain.
+     * @return string        The name of this domain's feedback source.
+     */
+    abstract protected function getSourceName(array $input);
+
+    /**
+     * Gets the tone of feedback from the given input.
+     * @param  array  $input The input for this domain.
+     * @return string        The tone of feedback.
+     */
+    protected function getTone(array $input)
+    {
+        return self::NEUTRAL;
+    }
+}

--- a/src/Domain/GetAppStore.php
+++ b/src/Domain/GetAppStore.php
@@ -37,7 +37,7 @@ class GetAppStore extends FeedbackGetDomain
 
     protected function getFeedbackItems()
     {
-        return $this->appStore->getReviews($_ENV['WIW_IOS_APP_ID'], $this->getRedisValue());
+        return $this->appStore->getReviews($this->getRedisValue());
     }
 
     protected function getValueForRedis($feedbackItem)

--- a/src/Domain/GetAppStore.php
+++ b/src/Domain/GetAppStore.php
@@ -1,10 +1,25 @@
 <?php
 namespace Wheniwork\Feedback\Domain;
 
+use Predis\Client as RedisClient;
 use Wheniwork\Feedback\Service\AppStoreService;
+use Wheniwork\Feedback\Service\GithubService;
+use Wheniwork\Feedback\Service\HipChatService;
 
 class GetAppStore extends FeedbackGetDomain
 {
+    private $appStore;
+
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        RedisClient $redis,
+        AppStoreService $appStore
+    ) {
+        parent::__construct($hipchat, $github, $redis);
+        $this->appStore = $appStore;
+    }
+
     protected function getRedisKey()
     {
         return "app_store_last_id";
@@ -22,7 +37,7 @@ class GetAppStore extends FeedbackGetDomain
 
     protected function getFeedbackItems()
     {
-        return AppStoreService::getReviews($_ENV['WIW_IOS_APP_ID'], $this->getRedisValue());
+        return $this->appStore->getReviews($_ENV['WIW_IOS_APP_ID'], $this->getRedisValue());
     }
 
     protected function getValueForRedis($feedbackItem)

--- a/src/Domain/GetBlog.php
+++ b/src/Domain/GetBlog.php
@@ -37,14 +37,13 @@ class GetBlog extends FeedbackGetDomain
 
     protected function getFeedbackItems()
     {
-        $comments = $this->blog->getPublishedComments(50, $this->getRedisValue());
+        $comments = $this->blog->getPublishedComments($this->getRedisValue(), true);
         $feedbackComments = [];
         foreach ($comments as $comment) {
             $is_reply = $comment['parent'] != "0";
-            $from_feedback_user = in_array($comment['user_id'], $this->getFeedbackUsers());
             $tagged_feedback = $this->isTaggedFeedback($comment['content']);
 
-            if ($is_reply && $from_feedback_user && $tagged_feedback) {
+            if ($is_reply && $tagged_feedback) {
                 $feedbackComments[] = $this->blog->getComment($comment['parent']);
             }
         }
@@ -61,10 +60,5 @@ class GetBlog extends FeedbackGetDomain
         $body = $feedbackItem['content'];
         $url = $feedbackItem['link'];
         return "$body<br><br><a href=\"$url\">$url</a>";
-    }
-
-    private function getFeedbackUsers()
-    {
-        return preg_split('/\s*,\s*/', $_ENV['WP_FEEDBACK_USERS']);
     }
 }

--- a/src/Domain/GetFacebook.php
+++ b/src/Domain/GetFacebook.php
@@ -71,7 +71,7 @@ class GetFacebook extends FeedbackGetDomain
 
     private function isFeedbackComment($comment)
     {
-        $from_wheniwork = $comment['from']['id'] == $_ENV['FB_PAGE_ID'];
+        $from_wheniwork = $comment['from']['id'] == $this->facebook->getPageId();
         $tagged_feedback = $this->isTaggedFeedback($comment['message']);
         return $from_wheniwork && $tagged_feedback;
     }

--- a/src/Domain/GetSatismeter.php
+++ b/src/Domain/GetSatismeter.php
@@ -1,10 +1,25 @@
 <?php
 namespace Wheniwork\Feedback\Domain;
 
+use Predis\Client as RedisClient;
+use Wheniwork\Feedback\Service\GithubService;
+use Wheniwork\Feedback\Service\HipChatService;
 use Wheniwork\Feedback\Service\SatismeterService;
 
 class GetSatismeter extends FeedbackGetDomain
 {
+    private $satismeter;
+    
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        RedisClient $redis,
+        SatismeterService $satismeter
+    ) {
+        parent::__construct($hipchat, $github, $redis);
+        $this->satismeter = $satismeter;
+    }
+
     protected function getRedisKey()
     {
         return "satismeter_last_time";
@@ -22,7 +37,7 @@ class GetSatismeter extends FeedbackGetDomain
 
     protected function getFeedbackItems()
     {
-        $responses = SatismeterService::getResponses($this->getRedisValue());
+        $responses = $this->satismeter->getResponses($this->getRedisValue());
         $feedbackResponses = [];
         foreach ($responses as $response) {
             if (empty($response->feedback)) {

--- a/src/Domain/GetTwitter.php
+++ b/src/Domain/GetTwitter.php
@@ -37,7 +37,7 @@ class GetTwitter extends FeedbackGetDomain
 
     protected function getFeedbackItems()
     {
-        $tweets = $this->getTweetsSince($this->getRedisValue());
+        $tweets = $this->twitter->getTweetsSince($this->getRedisValue());
         
         $feedbackTweets = [];
         foreach ($tweets as $tweet) {
@@ -62,24 +62,5 @@ class GetTwitter extends FeedbackGetDomain
         $body = $feedbackItem->text;
         $url = $this->getTweetURL($feedbackItem);
         return "$body<br><br><a href=\"$url\">$url</a>";
-    }
-
-    private function getTweetsSince($last_id) {
-        return $this->twitter->get('https://api.twitter.com/1.1/statuses/user_timeline.json', [
-            'screen_name' => $_ENV['TWITTER_WATCH_NAME'],
-            'since_id' => $last_id
-        ]);
-    }
-
-    private function getTweet($id) {
-        return $this->twitter->get('https://api.twitter.com/1.1/statuses/show.json', [
-            'id' => $id
-        ]);
-    }
-
-    private function getTweetURL($tweet) {
-        $screen_name = $tweet->user->screen_name;
-        $id_str = $tweet->id_str;
-        return "https://twitter.com/$screen_name/status/$id_str";
     }
 }

--- a/src/Domain/GetTwitter.php
+++ b/src/Domain/GetTwitter.php
@@ -1,11 +1,25 @@
 <?php
 namespace Wheniwork\Feedback\Domain;
 
+use Predis\Client as RedisClient;
+use Wheniwork\Feedback\Service\GithubService;
+use Wheniwork\Feedback\Service\HipChatService;
 use Wheniwork\Feedback\Service\TwitterService;
-use TwitterAPIExchange;
 
 class GetTwitter extends FeedbackGetDomain
 {
+    private $twitter;
+
+    public function __construct(
+        HipChatService $hipchat,
+        GithubService $github,
+        RedisClient $redis,
+        TwitterService $twitter
+    ) {
+        parent::__construct($hipchat, $github, $redis);
+        $this->twitter = $twitter;
+    }
+
     protected function getRedisKey()
     {
         return "twitter_last_id";
@@ -51,14 +65,14 @@ class GetTwitter extends FeedbackGetDomain
     }
 
     private function getTweetsSince($last_id) {
-        return TwitterService::get('https://api.twitter.com/1.1/statuses/user_timeline.json', [
+        return $this->twitter->get('https://api.twitter.com/1.1/statuses/user_timeline.json', [
             'screen_name' => $_ENV['TWITTER_WATCH_NAME'],
             'since_id' => $last_id
         ]);
     }
 
     private function getTweet($id) {
-        return TwitterService::get('https://api.twitter.com/1.1/statuses/show.json', [
+        return $this->twitter->get('https://api.twitter.com/1.1/statuses/show.json', [
             'id' => $id
         ]);
     }

--- a/src/Service/AppStoreService.php
+++ b/src/Service/AppStoreService.php
@@ -3,9 +3,16 @@ namespace Wheniwork\Feedback\Service;
 
 class AppStoreService
 {
-    public static function getReviews($app_id, $after_id)
+    private $app_id;
+
+    public function __construct($app_id)
     {
-        $endpoint = "https://itunes.apple.com/rss/customerreviews/id=$app_id/sortBy=mostRecent/json";
+        $this->app_id = $app_id;
+    }
+
+    public function getReviews($after_id)
+    {
+        $endpoint = "https://itunes.apple.com/rss/customerreviews/id=$this->app_id/sortBy=mostRecent/json";
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $endpoint);

--- a/src/Service/Authorizer.php
+++ b/src/Service/Authorizer.php
@@ -1,0 +1,17 @@
+<?php
+namespace Wheniwork\Feedback\Service;
+
+class Authorizer
+{
+    private $key;
+
+    public function __construct($key)
+    {
+        $this->key = $key;
+    }
+
+    public function checkInput(array $input)
+    {
+        return !empty($input['key']) && $input['key'] == $this->key;
+    }
+}

--- a/src/Service/Authorizer.php
+++ b/src/Service/Authorizer.php
@@ -1,6 +1,8 @@
 <?php
 namespace Wheniwork\Feedback\Service;
 
+use RuntimeException;
+
 class Authorizer
 {
     private $key;
@@ -10,8 +12,12 @@ class Authorizer
         $this->key = $key;
     }
 
-    public function checkInput(array $input)
+    public function ensure(array $input)
     {
-        return !empty($input['key']) && $input['key'] == $this->key;
+        if (empty($input['key'])) {
+            throw new RuntimeException("You must provide a key with your request.");
+        } else if ($input['key'] != $this->key) {
+            throw new RuntimeException("The provided authentication key was invalid.");
+        }
     }
 }

--- a/src/Service/BlogService.php
+++ b/src/Service/BlogService.php
@@ -5,10 +5,11 @@ use \HieuLe\WordpressXmlrpcClient\WordpressClient;
 
 class BlogService
 {
-    private static function getClient()
+    private $client;
+
+    public function __construct(WordpressClient $client)
     {
-        $wp = new WordpressClient($_ENV['WP_ENDPOINT'], $_ENV['WP_USER'], $_ENV['WP_PASSWORD']);
-        return $wp;
+        $this->client = $client;
     }
 
     /**
@@ -18,10 +19,9 @@ class BlogService
      *
      * @link https://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.getComment
      */
-    public static function getComment($comment_id)
+    public function getComment($comment_id)
     {
-        $wp = self::getClient();
-        return $wp->getComment($comment_id);
+        return $this->client->getComment($comment_id);
     }
 
     /**
@@ -33,10 +33,9 @@ class BlogService
      *
      * @link https://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.getComments
      */
-    public static function getPublishedComments($num_comments = 50, $after_time = 0)
+    public function getPublishedComments($num_comments = 50, $after_time = 0)
     {
-        $wp = self::getClient();
-        $comments = $wp->getComments([
+        $comments = $this->client->getComments([
             'status' => 'approve',
             'number' => $num_comments
         ]);

--- a/src/Service/FacebookService.php
+++ b/src/Service/FacebookService.php
@@ -104,5 +104,13 @@ class FacebookService
         }
         return $results['parent'];
     }
-    
+
+    /**
+     * Get the id of this service's page.
+     * @return int The page id.
+     */
+    public function getPageId()
+    {
+        return $this->page_id;
+    }    
 }

--- a/src/Service/FacebookService.php
+++ b/src/Service/FacebookService.php
@@ -1,6 +1,7 @@
 <?php
 namespace Wheniwork\Feedback\Service;
 
+use RuntimeException;
 use Facebook\Facebook;
 
 class FacebookService
@@ -33,7 +34,7 @@ class FacebookService
 
         if ($needs_authentication) {
             if (empty($this->app_token)) {
-                throw new \RuntimeException('You must authenticate before performing this request.');
+                throw new RuntimeException('You must authenticate before performing this request.');
             }
             $this->fb->setDefaultAccessToken($this->app_token);
         }

--- a/src/Service/GithubService.php
+++ b/src/Service/GithubService.php
@@ -5,22 +5,16 @@ use \Github\Client as GithubClient;
 
 class GithubService
 {
-    private static $client;
+    private $client;
 
-    private static function getClient()
+    public function __construct(GithubClient $client)
     {
-        if (empty(self::$client)) {
-            self::$client = new GithubClient;
-            self::$client->authenticate($_ENV['GITHUB_TOKEN'], "", GithubClient::AUTH_HTTP_TOKEN);
-        }
-        
-        return self::$client;
+        $this->client = $client;
     }
 
-    public static function createIssue($title, $body)
+    public function createIssue($title, $body)
     {
-        $client = self::getClient();
-        return $client->api('issue')->create(
+        return $this->client->api('issue')->create(
             'wheniwork',
             'loop-feed',
             [

--- a/src/Service/HipChatService.php
+++ b/src/Service/HipChatService.php
@@ -30,7 +30,7 @@ class HipChatService
         curl_setopt($ch, CURLOPT_POSTFIELDS, $postfields);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Authorization: Bearer ' . $_ENV['HIPCHAT_KEY'],
+            'Authorization: Bearer ' . $this->key,
             'Content-Type: application/json'
         ]);
 

--- a/src/Service/HipChatService.php
+++ b/src/Service/HipChatService.php
@@ -10,7 +10,16 @@ class HipChatService
     const PURPLE = "purple";
     const RANDOM = "random";
 
-    private static function post($endpoint, $params)
+    private $key;
+    private $room;
+
+    public function __construct($key, $room)
+    {
+        $this->key = $key;
+        $this->room = $room;
+    }
+
+    private function post($endpoint, $params)
     {
         $url = "https://api.hipchat.com/v2" . $endpoint;
         $postfields = json_encode($params);
@@ -31,9 +40,9 @@ class HipChatService
         return $response;
     }
 
-    public static function postMessage($content, $color = self::GRAY)
+    public function postMessage($content, $color = self::GRAY)
     {
-        self::post("/room/" . $_ENV['HIPCHAT_ROOM'] . "/notification", [
+        $this->post("/room/$this->room/notification", [
             'message' => $content,
             'color' => $color,
             'notify' => true

--- a/src/Service/SatismeterService.php
+++ b/src/Service/SatismeterService.php
@@ -5,12 +5,21 @@ use DateTime;
 
 class SatismeterService
 {
-    public static function getResponses($after_time)
+    private $key;
+    private $product_id;
+
+    public function __construct($key, $product_id)
+    {
+        $this->key = $key;
+        $this->product_id = $product_id;
+    }
+
+    public function getResponses($after_time)
     {
         $endpoint = "https://app.satismeter.com/api/responses";
         $params = http_build_query([
             'startDate' => date(DateTime::ISO8601, $after_time),
-            'project' => $_ENV['SATISMETER_PRODUCT_ID']
+            'project' => $this->product_id
         ]);
 
         $ch = curl_init();

--- a/src/Service/SatismeterService.php
+++ b/src/Service/SatismeterService.php
@@ -26,7 +26,7 @@ class SatismeterService
         curl_setopt($ch, CURLOPT_URL, $endpoint . '?' . $params);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['AuthKey: ' . $_ENV['SATISMETER_KEY']]);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['AuthKey: ' . $this->key]);
         $data = curl_exec($ch);
         curl_close($ch);
 

--- a/src/Service/TwitterService.php
+++ b/src/Service/TwitterService.php
@@ -7,12 +7,14 @@ use RuntimeException;
 class TwitterService
 {
     private $twitter;
+    private $screen_name;
 
-    public function __construct(TwitterAPIExchange $twitter) {
+    public function __construct(TwitterAPIExchange $twitter, $screen_name) {
         $this->twitter = $twitter;
+        $this->screen_name = $screen_name;
     }
 
-    public function get($request, $params = []) {
+    private function get($request, $params = []) {
         $getfield = "";
         if (!empty($params)) {
             $getfield = "?" . http_build_query($params);
@@ -30,5 +32,24 @@ class TwitterService
         }
 
         return $result;
+    }
+
+    public function getTweetsSince($last_id) {
+        return $this->get('https://api.twitter.com/1.1/statuses/user_timeline.json', [
+            'screen_name' => $this->screen_name,
+            'since_id' => $last_id
+        ]);
+    }
+
+    public function getTweet($id) {
+        return $this->get('https://api.twitter.com/1.1/statuses/show.json', [
+            'id' => $id
+        ]);
+    }
+
+    public function getTweetURL($tweet) {
+        $screen_name = $tweet->user->screen_name;
+        $id_str = $tweet->id_str;
+        return "https://twitter.com/$screen_name/status/$id_str";
     }
 }

--- a/src/Service/TwitterService.php
+++ b/src/Service/TwitterService.php
@@ -6,27 +6,22 @@ use RuntimeException;
 
 class TwitterService
 {
-    private static function getTwitter() {
-        $settings = [
-            'oauth_access_token' => $_ENV['TWITTER_OAUTH_TOKEN'],
-            'oauth_access_token_secret' => $_ENV['TWITTER_OAUTH_TOKEN_SECRET'],
-            'consumer_key' => $_ENV['TWITTER_CONSUMER_TOKEN'],
-            'consumer_secret' => $_ENV['TWITTER_CONSUMER_TOKEN_SECRET']
-        ];
-        return new TwitterAPIExchange($settings);
+    private $twitter;
+
+    public function __construct(TwitterAPIExchange $twitter) {
+        $this->twitter = $twitter;
     }
 
-    public static function get($request, $params = []) {
+    public function get($request, $params = []) {
         $getfield = "";
         if (!empty($params)) {
             $getfield = "?" . http_build_query($params);
         }
         
-        $twitter = self::getTwitter();
         $result = json_decode(
-            $twitter->setGetfield($getfield)
-            ->buildOauth($request, 'GET')
-            ->performRequest()
+            $this->twitter->setGetfield($getfield)
+                ->buildOauth($request, 'GET')
+                ->performRequest()
         );
 
         if (!empty($result->errors)) {

--- a/web/index.php
+++ b/web/index.php
@@ -2,14 +2,81 @@
 
 define('APP_PATH', realpath(__DIR__ . '/..') . DIRECTORY_SEPARATOR);
 
+use josegonzalez\Dotenv\Loader as EnvLoader;
+use Facebook\Facebook;
+use \Github\Client as GithubClient;
+use TwitterAPIExchange;
+use \HieuLe\WordpressXmlrpcClient\WordpressClient;
+
 require APP_PATH . 'vendor/autoload.php';
 
+$services = 'Wheniwork\Feedback\Service';
+
+// Initialize Injector
 $injector = new Auryn\Injector;
 $injector->define('Predis\Client', []);
+$injector->define(EnvLoader::class, [':filepaths' => __DIR__ . '/../.env']);
+$injector->prepare(EnvLoader::class, function(EnvLoader $loader) {
+    $loader->parse()->putenv(true);
+});
+$injector->delegate("$services\AppStoreService", function() {
+    return new Wheniwork\Feedback\Service\AppStoreService(
+        getenv('WIW_IOS_APP_ID')
+    );
+});
+$injector->delegate("$services\BlogService", function() {
+    $client = new WordpressClient(
+        "http://wheniwork.com/blog/xmlrpc.php",
+        getenv('WP_USER'),
+        getenv('WP_PASSWORD')
+    );
+    return new Wheniwork\Feedback\Service\BlogService($client);
+});
+$injector->delegate("$services\FacebookService", function() {
+    $fb = new Facebook([
+        'app_id' => getenv('FB_APP_ID'),
+        'app_secret' => getenv('FB_APP_SECRET'),
+        'default_graph_version' => 'v2.4'
+    ]);
+    $service = new Wheniwork\Feedback\Service\FacebookService($fb, getenv('FB_PAGE_ID'));
+    $service->authenticate(
+        getenv('FB_APP_ID'),
+        getenv('FB_APP_SECRET')
+    );
+    return $service;
+});
+$injector->delegate("$services\GithubService", function() {
+    $client = new GithubClient;
+    $client->authenticate(getenv('GITHUB_TOKEN'), "", GithubClient::AUTH_HTTP_TOKEN);
+    return new Wheniwork\Feedback\Service\GithubService($client);
+});
+$injector->delegate("$services\HipChatService", function() {
+    return new Wheniwork\Feedback\Service\HipChatService(
+        getenv('HIPCHAT_KEY'),
+        getenv('HIPCHAT_ROOM')
+    );
+});
+$injector->delegate("$services\SatismeterService", function() {
+    return new Wheniwork\Feedback\Service\SatismeterService(
+        getenv('SATISMETER_KEY'),
+        getenv('SATISMETER_PRODUCT_ID')
+    );
+});
+$injector->delegate("$services\TwitterService", function() {
+    $twitter = new TwitterAPIExchange([
+        'oauth_access_token' => getenv('TWITTER_OAUTH_TOKEN'),
+        'oauth_access_token_secret' => getenv('TWITTER_OAUTH_TOKEN_SECRET'),
+        'consumer_key' => getenv('TWITTER_CONSUMER_TOKEN'),
+        'consumer_secret' => getenv('TWITTER_CONSUMER_TOKEN_SECRET')
+    ]);
+    return new Wheniwork\Feedback\Service\TwitterService($twitter);
+});
 
+// Boot app
 $app = Spark\Application::boot($injector);
 $app->getRouter()->setDefaultResponder('Spark\Responder\JsonResponder');
 
+// Add routes
 $app->addRoutes(function(Spark\Router $r) {
     $ns = 'Wheniwork\Feedback';
 


### PR DESCRIPTION
This one is huge. All services have been refactored to not use static, and all dependencies for those services are now handled through the injector. All GET domains now require their specific service in their
constructor, which is what allows the injector to work its magic in the first place.

Each endpoint has been tested...somewhat thoroughly. More thorough testing will happen when other refactoring tasks are complete.

I really recommend just looking at the code from scratch for this one. The diff is insane. Sorry it's not easier to follow, but refactoring this touches most of the files in the project.

Hopefully resolves #2!
